### PR TITLE
fix: remove install dir prefix and correct datetime_de comment targets

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,14 +1,11 @@
-#EXTENSION    = pgsql_tweaks
 EXTENSION    = $(shell grep -m 1 '"name":' META.json | \
                sed -e 's/[[:space:]]*"name":[[:space:]]*"\([^"]*\)",/\1/')
 EXTVERSION   = $(shell grep -m 1 '"version":' META.json | \
                sed -e 's/[[:space:]]*"version":[[:space:]]*"\([^"]*\)",/\1/')
 
-MODULEDIR    = pgsql_tweaks
-NUMVERSION   = $(shell echo $(EXTVERSION) | sed -e 's/\([[:digit:]]*[.][[:digit:]]*\).*/\1/')
 DATA         = sql/$(EXTENSION)--$(EXTVERSION).sql
 TESTS        = test/$(EXTENSION)_test--$(EXTVERSION).sql
-REGRESS		 = test/$(EXTENSION)_test--$(EXTVERSION)
+REGRESS      = test/$(EXTENSION)_test--$(EXTVERSION)
 DOCS         = README.md
 
 PG_CONFIG    = pg_config

--- a/sql/function_datetime_de.sql
+++ b/sql/function_datetime_de.sql
@@ -12,4 +12,4 @@
  $$
  STRICT
  LANGUAGE plpgsql IMMUTABLE;
- COMMENT ON FUNCTION datetime_de(t TIMESTAMP) IS 'Creates a function which returns the given timestamp in German format';
+ COMMENT ON FUNCTION datetime_de(t TIMESTAMP WITH TIME ZONE, with_tz BOOLEAN) IS 'Creates a function which returns the given timestamp in German format';

--- a/sql/pgsql_tweaks--0.1.0.sql
+++ b/sql/pgsql_tweaks--0.1.0.sql
@@ -557,7 +557,7 @@ COMMENT ON AGGREGATE gap_fill(anyelement) IS 'Implements the aggregate function 
  $$
  STRICT
  LANGUAGE plpgsql IMMUTABLE;
- COMMENT ON FUNCTION datetime_de(t TIMESTAMP) IS 'Creates a function which returns the given timestamp in German format';
+ COMMENT ON FUNCTION datetime_de(t TIMESTAMP WITH TIME ZONE, with_tz BOOLEAN) IS 'Creates a function which returns the given timestamp in German format';
 
 /**
  * Creates two functions which returns unix timestamp for the a given timestamp


### PR DESCRIPTION
hey, these are cool! I had a bit of trouble getting them installed: with the makefile creating a pgsql_tweaks directory under /extensions, `create extension pgsql_tweaks` returns the error message `extension "pgsql_tweaks" has no installation script nor update path for version "0.1.0"`. This fixes that by removing MODULEDIR so the SQL files go into /extensions like everything else does (and NUMVERSION wasn't being used). There were also a couple of `COMMENT ON` statements that prevented installation.

Have you thought about publishing this to [pgxn](https://pgxn.org/) ?